### PR TITLE
Added imageUri to extra attributes

### DIFF
--- a/custom_components/nintendo_switch/binary_sensor.py
+++ b/custom_components/nintendo_switch/binary_sensor.py
@@ -135,4 +135,7 @@ class FriendSensor(BinarySensorEntity, CoordinatorEntity):
         self._attr_extra_state_attributes["game"] = (
             friend["presence"].get("game", {}).get("name", "---")
         )
+        self._attr_extra_state_attributes["cover image"] = (
+            friend["presence"].get("game", {}).get("imageUri", "")
+        )
         self.async_write_ha_state()


### PR DESCRIPTION
### Summary
This small enhancement to the Nintendo Switch integration adds the cover art of the currently played game as an additional attribute to the binary sensor. This can be used to display the game's cover art on a dashboard.


### Changes
- Added a new cover image attribute to the sensor's extra state attributes.
- The cover image attribute is populated with the URI of the game's cover art, retrieved from the imageUri field within the game presence data.
- If no cover art is available, the attribute defaults to an empty string.

