### PR TITLE
Fix Unexpected Error

### DIFF
--- a/custom_components/nintendo_switch/manifest.json
+++ b/custom_components/nintendo_switch/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MiguelAngelLV/ha-nintendo-switch/issues",
   "requirements": [
-    "nso-api>=0.9.12",
+    "nso-api==0.9.16",
     "beautifulsoup4>=4.0.1",
     "itunes-app-scraper-dmi>=0.9.1"
   ],

--- a/custom_components/nintendo_switch/translations/en.json
+++ b/custom_components/nintendo_switch/translations/en.json
@@ -3,6 +3,9 @@
     "error": {
       "unknown": "Unexpected error"
     },
+    "abort": {
+      "single_instance_allowed": "Only one instance of this integration is allowed."
+    },
     "step": {
       "user": {
         "description": "You need to access [this link]({url}), log in with your Nintendo account, and right-click on the 'Choose person' button to copy the session address.",

--- a/custom_components/nintendo_switch/translations/es.json
+++ b/custom_components/nintendo_switch/translations/es.json
@@ -3,6 +3,9 @@
     "error": {
       "unknown": "Error inesperado"
     },
+    "abort": {
+      "single_instance_allowed": "Solo se permite una instancia de esta integración."
+    },
     "step": {
       "user": {
         "description": "Debes acceder a [este enlace]({url}), identificarse con su cuenta de Nintendo y, con el botón derecho en el botón «Elegir persona», copiar la dirección de sesion",


### PR DESCRIPTION
Nintendo has removed the endpoint that allowed retrieving user information. Since this data was only used for the configured account's information, it has been replaced with fixed values, which means multiple accounts can no longer be added.

Users who have already configured their account will not be affected by this change.